### PR TITLE
[docs] hasPrefix and hasSuffix don't match scalars

### DIFF
--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -64,10 +64,10 @@ extension StringProtocol {
   ///     print(cafe.hasPrefix("café"))
   ///     // Prints "false"
   ///
-  /// The Unicode-safe comparison matches Unicode scalar values rather than the
-  /// code points used to compose them. The example below uses two strings
-  /// with different forms of the `"é"` character---the first uses the composed
-  /// form and the second uses the decomposed form.
+  /// The Unicode-safe comparison matches Unicode extended grapheme clusters
+  /// rather than the code points used to compose them. The example below uses
+  /// two strings with different forms of the `"é"` character---the first uses
+  /// the composed form and the second uses the decomposed form.
   ///
   ///     // Unicode safe
   ///     let composedCafe = "Café"
@@ -98,10 +98,10 @@ extension StringProtocol {
   ///     print(plans.hasSuffix("Café"))
   ///     // Prints "false"
   ///
-  /// The Unicode-safe comparison matches Unicode scalar values rather than the
-  /// code points used to compose them. The example below uses two strings
-  /// with different forms of the `"é"` character---the first uses the composed
-  /// form and the second uses the decomposed form.
+  /// The Unicode-safe comparison matches Unicode extended grapheme clusters
+  /// rather than the code points used to compose them. The example below uses
+  /// two strings with different forms of the `"é"` character---the first uses
+  /// the composed form and the second uses the decomposed form.
   ///
   ///     // Unicode safe
   ///     let composedCafe = "café"


### PR DESCRIPTION
<!-- What's in this pull request? -->
Resolves an error in the Swift documentation for `hasPrefix` and `hasSuffix` discussed [on the forums](
https://forums.swift.org/t/hassuffix/19699).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
