### PR TITLE
[stdlib] Make unavailable protocol implementation `@_alwaysEmitIntoClient`

### DIFF
--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -71,6 +71,7 @@ extension RandomNumberGenerator {
   // unsigned integer will be used, recursing infinitely and probably blowing
   // the stack.
   @available(*, unavailable)
+  @_alwaysEmitIntoClient
   public mutating func next() -> UInt64 { fatalError() }
   
   /// Returns a value from a uniform, independent distribution of binary data.
@@ -103,6 +104,9 @@ extension RandomNumberGenerator {
     upperBound: T
   ) -> T {
     _precondition(upperBound != 0, "upperBound cannot be zero.")
+    // We use Lemire's "nearly divisionless" method for generating random
+    // integers in an interval. For a detailed explanation, see:
+    // https://arxiv.org/abs/1805.10941
     var random: T = next()
     var m = random.multipliedFullWidth(by: upperBound)
     if m.low < upperBound {


### PR DESCRIPTION
…and add a comment about use of Lemire's nearly divisionless method.

In follow-up to #38161, make the clever recursion-breaking protocol implementation `@_alwaysEmitIntoClient` in addition to being unavailable. Additionally, in follow-up to #25286, add a brief comment in the code about the use of Lemire's nearly divisionless method; the code is very neat but without any comment a reader who is unfamiliar with the algorithm has no easy way of understanding what's going on.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
